### PR TITLE
Add classes/ignore_index to losses

### DIFF
--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -5,6 +5,7 @@ import torchseg
 import torchseg.losses._functional as F
 from torchseg.losses import (
     DiceLoss,
+    FocalLoss,
     JaccardLoss,
     MCCLoss,
     SoftBCEWithLogitsLoss,
@@ -333,3 +334,15 @@ def test_binary_mcc_loss():
 
     loss = criterion(y_pred, y_true)
     assert float(loss) == pytest.approx(0.5, abs=eps)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("loss_fn", [DiceLoss, JaccardLoss, FocalLoss])
+@pytest.mark.parametrize("classes", [None, [1]])
+@pytest.mark.parametrize("ignore_index", [None, 0, -255])
+def test_classes_arg(loss_fn, classes, ignore_index):
+    criterion = loss_fn(mode="multiclass", classes=classes, ignore_index=ignore_index)
+    y_pred = torch.zeros(1, 2, 128, 128, dtype=torch.float)
+    y_pred[:, 0, ...] = 1.0
+    y_true = torch.ones(1, 128, 128, dtype=torch.long)
+    criterion(y_pred, y_true)

--- a/torchseg/losses/focal.py
+++ b/torchseg/losses/focal.py
@@ -18,6 +18,7 @@ class FocalLoss(nn.Module):
         reduction: Optional[str] = "mean",
         normalized: bool = False,
         reduced_threshold: Optional[float] = None,
+        classes: Optional[list[int]] = None,
     ):
         """Compute Focal loss
 
@@ -30,6 +31,8 @@ class FocalLoss(nn.Module):
             normalized: Use normalized focal loss (https://arxiv.org/pdf/1909.07829.pdf)
             reduced_threshold: Switch to reduced focal loss.
                 Note, when using this mode you should use `reduction="sum"`.
+            classes:  List of classes that contribute in loss computation.
+                By default, all channels are included. Only supported in multiclass mode
 
         Shape
              - **y_pred** - torch.Tensor of shape (N, C, H, W)
@@ -44,6 +47,7 @@ class FocalLoss(nn.Module):
 
         self.mode = mode
         self.ignore_index = ignore_index
+        self.classes = classes
         self.focal_loss_fn = partial(
             focal_loss_with_logits,
             alpha=alpha,
@@ -75,13 +79,14 @@ class FocalLoss(nn.Module):
                 not_ignored = y_true != self.ignore_index
 
             for cls in range(num_classes):
-                cls_y_true = (y_true == cls).long()
-                cls_y_pred = y_pred[:, cls, ...]
+                if self.classes is None or cls in self.classes:
+                    cls_y_true = (y_true == cls).long()
+                    cls_y_pred = y_pred[:, cls, ...]
 
-                if self.ignore_index is not None:
-                    cls_y_true = cls_y_true[not_ignored]
-                    cls_y_pred = cls_y_pred[not_ignored]
+                    if self.ignore_index is not None:
+                        cls_y_true = cls_y_true[not_ignored]
+                        cls_y_pred = cls_y_pred[not_ignored]
 
-                loss += self.focal_loss_fn(cls_y_pred, cls_y_true)
+                    loss += self.focal_loss_fn(cls_y_pred, cls_y_true)
 
         return loss


### PR DESCRIPTION
Some of the loss functions use either `ignore_index`, `classes`, or in some cases both. However some losses are are able to support both. This PR adds the following:

- Support `classes` in `FocalLoss`
- Support `ignore_index` in `JaccardLoss`

See https://github.com/isaaccorley/torchseg/issues/7
