### PR TITLE
Overhaul of torchseg.losses

### DIFF
--- a/torchseg/losses/__init__.py
+++ b/torchseg/losses/__init__.py
@@ -1,4 +1,5 @@
 from .constants import BINARY_MODE, MULTICLASS_MODE, MULTILABEL_MODE
+from .reductions import LossReduction
 from .dice import DiceLoss
 from .focal import FocalLoss
 from .jaccard import JaccardLoss
@@ -12,6 +13,7 @@ __all__ = (
     "BINARY_MODE",
     "MULTICLASS_MODE",
     "MULTILABEL_MODE",
+    "LossReduction",
     "DiceLoss",
     "FocalLoss",
     "JaccardLoss",

--- a/torchseg/losses/_functional.py
+++ b/torchseg/losses/_functional.py
@@ -165,17 +165,22 @@ def soft_jaccard_score(
 def soft_dice_score(
     output: torch.Tensor,
     target: torch.Tensor,
+    power: float =  1.0,
     smooth: float = 0.0,
     eps: float = 1e-7,
-    dims=None,
+    dims = None,
 ) -> torch.Tensor:
     assert output.size() == target.size()
     if dims is not None:
-        intersection = torch.sum(output * target, dim=dims)
-        cardinality = torch.sum(output + target, dim=dims)
+        intersection = torch.sum(output * target, dim = dims)
+        output_pow = torch.sum(output ** power, dim = dims)
+        target_pow = torch.sum(target ** power, dim = dims)
+        cardinality = output_pow + target_pow
     else:
         intersection = torch.sum(output * target)
-        cardinality = torch.sum(output + target)
+        output_pow = torch.sum(output ** power)
+        target_pow = torch.sum(target ** power)
+        cardinality = output_pow + target_pow
     dice_score = (2.0 * intersection + smooth) / (cardinality + smooth).clamp_min(eps)
     return dice_score
 

--- a/torchseg/losses/constants.py
+++ b/torchseg/losses/constants.py
@@ -1,18 +1,18 @@
 #: Loss binary mode suppose you are solving binary segmentation task.
-#: That mean yor have only one class which pixels are labled as **1**,
-#: the rest pixels are background and labeled as **0**.
+#: That mean yor have only one class which pixels are labeled as **1**,
+#: the remaining pixels are background and labeled as **0**.
 #: Target mask shape - (N, H, W), model output mask shape (N, 1, H, W).
 BINARY_MODE: str = "binary"
 
 #: Loss multiclass mode suppose you are solving multi-**class** segmentation task.
 #: That mean you have *C = 1..N* classes which have unique label values,
-#: classes are mutually exclusive and all pixels are labeled with theese values.
+#: classes are mutually exclusive and all pixels are labeled with these values.
 #: Target mask shape - (N, H, W), model output mask shape (N, C, H, W).
 MULTICLASS_MODE: str = "multiclass"
 
 #: Loss multilabel mode suppose you are solving multi-**label** segmentation task.
 #: That mean you have *C = 1..N* classes which pixels are labeled as **1**,
 #: classes are not mutually exclusive and each class have its own *channel*,
-#: pixels in each channel which are not belong to class labeled as **0**.
+#: pixels in each channel which do not belong to class are labeled as **0**.
 #: Target mask shape - (N, C, H, W), model output mask shape (N, C, H, W).
 MULTILABEL_MODE: str = "multilabel"

--- a/torchseg/losses/dice.py
+++ b/torchseg/losses/dice.py
@@ -24,9 +24,11 @@ class DiceLoss(nn.Module):
             eps: float = 1e-7,
     ):
         """
-        DA RISCRIVERE
         Dice loss for image segmentation task.
-        It supports binary, multiclass and multilabel cases
+        It supports binary, multiclass and multilabel cases.
+        Ground truth masks should have shape (B, C, H, W) for multiclass and multilabel cases
+        or (B, 1, H, W) for binary case. For the multiclass case, the ground truth mask can also
+        have shape (B, 1, H, W) but you should set mask_to_one_hot = True.
 
         Args:
             - mode: Loss mode 'binary', 'multiclass' or 'multilabel'
@@ -76,12 +78,17 @@ class DiceLoss(nn.Module):
                 self.classes = to_tensor(self.classes, dtype = torch.long)
 
         if self.from_logits:
+            # Convert logits to class probabilities using Sigmoid for Binary Case
+            # and Softmax for multiclass/multilabels cases.
+            # Using log-exp formulation as it is more numerically stable
+            # and does not cause vanishing gradient.
             if num_classes == 1:
                 y_pred = F.logsigmoid(y_pred).exp()
             else:
                 y_pred = F.log_softmax(y_pred, dim = 1).exp()
 
         if self.mask_to_one_hot:
+            # Convert y_true to one_hot representation to compute DiceLoss
             if num_classes == 1:
                 warnings.warn("Single channel prediction, 'mask_to_one_hot = True' ignored.")
             else:
@@ -135,155 +142,5 @@ class DiceLoss(nn.Module):
         elif self.reduction == LossReduction.NONE:
             broadcast_shape = list(loss.shape[0:2]) + [1] * (len(y_true.shape) - 2)
             loss = loss.view(broadcast_shape)
-
-        return loss
-
-
-
-
-class DiceLossOld(nn.Module):
-    def __init__(
-        self,
-        mode: str,
-        classes: Optional[list[int]] = None,
-        log_loss: bool = False,
-        from_logits: bool = True,
-        power: float= 1.0,
-        reduction: str = 'mean',
-        smooth: float = 0.0,
-        ignore_index: Optional[int] = None,
-        eps: float = 1e-7,
-    ):
-        """
-        Dice loss for image segmentation task.
-        It supports binary, multiclass and multilabel cases
-
-        Args:
-            - mode: Loss mode 'binary', 'multiclass' or 'multilabel'
-            - classes:  List of classes that contribute in loss computation.
-                By default, all channels are included.
-            - log_loss: If True, loss computed as `- log(dice_coeff)`,
-                otherwise `1 - dice_coeff`
-            - from_logits: If True, assumes input is raw logits
-            - smooth: Smoothness constant for dice coefficient
-                added to the numerator to avoid zero
-            - ignore_index: Label that indicates ignored pixels
-                (does not contribute to loss)
-            - eps: A small epsilon for numerical stability to avoid zero division error
-                (denominator will be always greater or equal to eps)
-
-        Shape
-             - **y_pred** - torch.Tensor of shape (N, C, H, W)
-             - **y_true** - torch.Tensor of shape (N, H, W) or (N, C, H, W)
-
-        Reference
-            https://github.com/BloodAxe/pytorch-toolbelt
-        """
-        if mode not in {BINARY_MODE, MULTILABEL_MODE, MULTICLASS_MODE}:
-            raise ValueError(f'Unsupported mode: {mode}, '
-                             f'available options are ["binary", "multiclass", "multilabel"].')
-        if reduction not in {MEAN_REDUCTION, SUM_REDUCTION, NONE_REDUCTION}:
-            raise ValueError(f'Unsupported reduction: {reduction}, '
-                             f'available options are ["mean", "sum", "none"].')
-        super().__init__()
-        self.mode = mode
-        if classes is not None:
-            assert (
-                mode != BINARY_MODE
-            ), "Masking classes is not supported with mode=binary"
-            classes = to_tensor(classes, dtype = torch.long)
-
-        self.classes = classes
-        self.from_logits = from_logits
-        self.power = power
-        self.reduction = reduction
-        self.smooth = smooth
-        self.eps = eps
-        self.log_loss = log_loss
-        self.ignore_index = ignore_index
-
-    def forward(self, y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
-        assert y_true.size(0) == y_pred.size(0)
-
-        bs = y_true.size(0)
-        num_classes = y_pred.size(1)
-        height, width = y_pred.size(2), y_pred.size(3)
-        dims = (0, 2)
-
-        if self.from_logits:
-            # Apply activations to get [0..1] class probabilities
-            # Using Log-Exp as this gives more numerically stable
-            # result and does not cause vanishing gradient on
-            # extreme values 0 and 1
-            if self.mode == MULTICLASS_MODE:
-                y_pred = y_pred.log_softmax(dim=1).exp()
-            else:
-                y_pred = F.logsigmoid(y_pred).exp()
-
-        if self.mode == BINARY_MODE:
-            y_true = y_true.view(bs, 1, -1)
-            y_pred = y_pred.view(bs, 1, -1)
-
-            if self.ignore_index is not None:
-                mask = y_true != self.ignore_index
-                y_pred = y_pred * mask
-                y_true = y_true * mask
-
-        if self.mode == MULTICLASS_MODE:
-            y_true = y_true.view(bs, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
-
-            if self.ignore_index is not None:
-                mask = y_true != self.ignore_index
-                y_pred = y_pred * mask.unsqueeze(1)
-
-                y_true = F.one_hot(
-                    (y_true * mask).to(torch.long), num_classes
-                )  # N,H*W -> N,H*W, C
-                y_true = y_true.permute(0, 2, 1) * mask.unsqueeze(1)  # N, C, H*W
-            else:
-                y_true = F.one_hot(y_true, num_classes)  # N,H*W -> N,H*W, C
-                y_true = y_true.permute(0, 2, 1)  # N, C, H*W
-
-        if self.mode == MULTILABEL_MODE:
-            y_true = y_true.view(bs, num_classes, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
-
-            if self.ignore_index is not None:
-                mask = y_true != self.ignore_index
-                y_pred = y_pred * mask
-                y_true = y_true * mask
-
-        scores = soft_dice_score(y_pred,
-                                 y_true.type_as(y_pred),
-                                 power = self.power,
-                                 smooth = self.smooth,
-                                 eps = self.eps,
-                                 dims = dims)
-
-        print("shape of scores: ", scores.shape)
-
-        if self.log_loss:
-            loss = -torch.log(scores.clamp_min(self.eps))
-        else:
-            loss = 1.0 - scores
-
-        # Dice loss is undefined for non-empty classes
-        # So we zero contribution of channel that does not have true pixels
-        # NOTE: A better workaround would be to use loss term `mean(y_pred)`
-        # for this case, however it will be a modified jaccard loss
-        # ---> to check
-        mask = y_true.sum(dims) > 0
-        loss *= mask.to(loss.dtype)
-
-        if self.classes is not None:
-            loss = loss[self.classes]
-
-        if self.reduction == MEAN_REDUCTION:
-            loss = torch.mean(loss)
-        elif self.reduction == SUM_REDUCTION:
-            loss = torch.sum(loss)
-        elif self.reduction == NONE_REDUCTION:
-            loss = loss.view(bs, num_classes, height, width)
 
         return loss

--- a/torchseg/losses/dice.py
+++ b/torchseg/losses/dice.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import torch
@@ -6,33 +7,169 @@ import torch.nn.functional as F
 
 from ._functional import soft_dice_score, to_tensor
 from .constants import BINARY_MODE, MULTICLASS_MODE, MULTILABEL_MODE
+from .reductions import LossReduction
 
 
 class DiceLoss(nn.Module):
+    def __init__(
+            self,
+            classes: Optional[list[int]] = None,
+            log_loss: bool = False,
+            from_logits: bool = True,
+            mask_to_one_hot: bool = False,
+            power: float = 1.0,
+            reduction: str = 'mean',
+            smooth: float = 0.0,
+            ignore_index: Optional[int] = None,
+            eps: float = 1e-7,
+    ):
+        """
+        DA RISCRIVERE
+        Dice loss for image segmentation task.
+        It supports binary, multiclass and multilabel cases
+
+        Args:
+            - mode: Loss mode 'binary', 'multiclass' or 'multilabel'
+            - classes:  List of classes that contribute in loss computation.
+                By default, all channels are included.
+            - log_loss: If True, loss computed as `- log(dice_coeff)`,
+                otherwise `1 - dice_coeff`
+            - from_logits: If True, assumes input is raw logits
+            - ignore_index: Label that indicates ignored pixels  not contributing to the loss
+            - smooth: Smoothness constant for dice coefficient added to the numerator to avoid zero
+            - eps: A small epsilon added to the denominator  for numerical stability to avoid nan
+                (denominator will be always greater or equal to eps)
+
+        Shape
+             - **y_pred** - torch.Tensor of shape (B, C, H, W),
+             - **y_true** - torch.Tensor of shape (B, C, H, W) or (B, 1, H, W),
+        where C is the number of classes.
+
+        Reference
+            https://docs.monai.io/en/stable/_modules/monai/losses/dice.html#DiceLoss
+        """
+        if reduction not in LossReduction.available_reductions():
+            raise ValueError(f'Unsupported reduction: {reduction}, '
+                             f'available options are {LossReduction.available_reductions()}.')
+        super().__init__()
+
+        self.classes = classes
+        self.from_logits = from_logits
+        self.mask_to_one_hot = mask_to_one_hot
+        self.power = power
+        self.reduction = reduction
+        self.smooth = smooth
+        self.eps = eps
+        self.log_loss = log_loss
+        self.ignore_index = ignore_index
+
+    def forward(self, y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
+        batch_size = y_pred.shape[0]
+        num_classes = y_pred.shape[1]
+        spatial_dims: list[int] = torch.arange(2, len(y_pred.shape)).tolist()
+        if self.classes is not None:
+            assert (
+                    num_classes > 1
+            ), "Masking classes is not supported for Binary Segmentation"
+            self.classes = to_tensor(self.classes, dtype = torch.long)
+
+        if self.from_logits:
+            if num_classes == 1:
+                y_pred = F.log_softmax(y_pred, dim = 1).exp()
+            else:
+                y_pred = F.logsigmoid(y_pred).exp()
+
+        if self.mask_to_one_hot:
+            if num_classes == 1:
+                warnings.warn("Single channel prediction, 'mask_to_one_hot = True' ignored.")
+            else:
+                # maybe there is a better way to handle this?
+                permute_dims = tuple(dim - 1 for dim in spatial_dims)
+                y_true = F.one_hot(y_true, num_classes) # N, H, W, ... ---> N, H, W, ..., C
+                y_true = y_true.permute(0, -1, *permute_dims) # N, H, W, ..., C ---> N, C, H, W, ...
+
+        if y_true.shape != y_pred.shape:
+            raise AssertionError(f"Ground truth has different shape ({y_true.shape})"
+                                 f" from predicted mask ({y_pred.shape})")
+
+        # Only reduce spatial dimensions
+        scores = soft_dice_score(y_pred,
+                                 y_true.type_as(y_pred),
+                                 power = self.power,
+                                 smooth = self.smooth,
+                                 eps = self.eps,
+                                 dims = spatial_dims)
+
+        print("shape of scores: ", scores.shape) # DEBUG
+
+        if self.log_loss:
+            loss = -torch.log(scores.clamp_min(self.eps))
+        else:
+            loss = 1.0 - scores
+
+        # Dice loss is defined for non-empty classes
+        # So we zero contribution of channel that does not have true pixels
+        # NOTE: A better workaround would be to use loss term `mean(y_pred)`
+        # for this case, however it will be a modified jaccard loss
+        """
+        Personal Opinion: maybe this can be skipped. By summing over batch
+        and spatial dimensions I think the idea is: I constantly have channels
+        with pixels = 0 which should not be included in the loss computation,
+        but if this happens there is something wrong with the masks.
+        While by just summing over spatial dimensions it means that an empty channel
+        should not be used to compute the DiceLoss, but it may simply mean
+        that the specific class is not present in this specific mask.
+        """
+        # to delete?
+        #dims = tuple(d for d in range(len(y_true.shape)) if d != 1)
+        #mask = y_true.sum(dims) > 0
+        #loss *= mask.to(loss.dtype)
+
+        if self.classes is not None:
+            loss = loss[self.classes]
+
+        if self.reduction == LossReduction.MEAN:
+            loss = torch.mean(loss)
+        elif self.reduction == LossReduction.SUM:
+            loss = torch.sum(loss)
+        elif self.reduction == LossReduction.NONE:
+            broadcast_shape = list(loss.shape[0:2]) + [1] * (len(y_true.shape) - 2)
+            loss = loss.view(broadcast_shape)
+
+        return loss
+
+
+
+
+class DiceLossOld(nn.Module):
     def __init__(
         self,
         mode: str,
         classes: Optional[list[int]] = None,
         log_loss: bool = False,
         from_logits: bool = True,
+        power: float= 1.0,
+        reduction: str = 'mean',
         smooth: float = 0.0,
         ignore_index: Optional[int] = None,
         eps: float = 1e-7,
     ):
-        """Dice loss for image segmentation task.
+        """
+        Dice loss for image segmentation task.
         It supports binary, multiclass and multilabel cases
 
         Args:
-            mode: Loss mode 'binary', 'multiclass' or 'multilabel'
-            classes:  List of classes that contribute in loss computation.
+            - mode: Loss mode 'binary', 'multiclass' or 'multilabel'
+            - classes:  List of classes that contribute in loss computation.
                 By default, all channels are included.
-            log_loss: If True, loss computed as `- log(dice_coeff)`,
+            - log_loss: If True, loss computed as `- log(dice_coeff)`,
                 otherwise `1 - dice_coeff`
-            from_logits: If True, assumes input is raw logits
-            smooth: Smoothness constant for dice coefficient (a)
-            ignore_index: Label that indicates ignored pixels
+            - from_logits: If True, assumes input is raw logits
+            - smooth: Smoothness constant for dice coefficient
+                added to the numerator to avoid zero
+            - ignore_index: Label that indicates ignored pixels
                 (does not contribute to loss)
-            eps: A small epsilon for numerical stability to avoid zero division error
+            - eps: A small epsilon for numerical stability to avoid zero division error
                 (denominator will be always greater or equal to eps)
 
         Shape
@@ -42,17 +179,24 @@ class DiceLoss(nn.Module):
         Reference
             https://github.com/BloodAxe/pytorch-toolbelt
         """
-        assert mode in {BINARY_MODE, MULTILABEL_MODE, MULTICLASS_MODE}
+        if mode not in {BINARY_MODE, MULTILABEL_MODE, MULTICLASS_MODE}:
+            raise ValueError(f'Unsupported mode: {mode}, '
+                             f'available options are ["binary", "multiclass", "multilabel"].')
+        if reduction not in {MEAN_REDUCTION, SUM_REDUCTION, NONE_REDUCTION}:
+            raise ValueError(f'Unsupported reduction: {reduction}, '
+                             f'available options are ["mean", "sum", "none"].')
         super().__init__()
         self.mode = mode
         if classes is not None:
             assert (
                 mode != BINARY_MODE
             ), "Masking classes is not supported with mode=binary"
-            classes = to_tensor(classes, dtype=torch.long)
+            classes = to_tensor(classes, dtype = torch.long)
 
         self.classes = classes
         self.from_logits = from_logits
+        self.power = power
+        self.reduction = reduction
         self.smooth = smooth
         self.eps = eps
         self.log_loss = log_loss
@@ -60,6 +204,11 @@ class DiceLoss(nn.Module):
 
     def forward(self, y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
         assert y_true.size(0) == y_pred.size(0)
+
+        bs = y_true.size(0)
+        num_classes = y_pred.size(1)
+        height, width = y_pred.size(2), y_pred.size(3)
+        dims = (0, 2)
 
         if self.from_logits:
             # Apply activations to get [0..1] class probabilities
@@ -70,10 +219,6 @@ class DiceLoss(nn.Module):
                 y_pred = y_pred.log_softmax(dim=1).exp()
             else:
                 y_pred = F.logsigmoid(y_pred).exp()
-
-        bs = y_true.size(0)
-        num_classes = y_pred.size(1)
-        dims = (0, 2)
 
         if self.mode == BINARY_MODE:
             y_true = y_true.view(bs, 1, -1)
@@ -109,9 +254,14 @@ class DiceLoss(nn.Module):
                 y_pred = y_pred * mask
                 y_true = y_true * mask
 
-        scores = self.compute_score(
-            y_pred, y_true.type_as(y_pred), smooth=self.smooth, eps=self.eps, dims=dims
-        )
+        scores = soft_dice_score(y_pred,
+                                 y_true.type_as(y_pred),
+                                 power = self.power,
+                                 smooth = self.smooth,
+                                 eps = self.eps,
+                                 dims = dims)
+
+        print("shape of scores: ", scores.shape)
 
         if self.log_loss:
             loss = -torch.log(scores.clamp_min(self.eps))
@@ -122,19 +272,18 @@ class DiceLoss(nn.Module):
         # So we zero contribution of channel that does not have true pixels
         # NOTE: A better workaround would be to use loss term `mean(y_pred)`
         # for this case, however it will be a modified jaccard loss
-
+        # ---> to check
         mask = y_true.sum(dims) > 0
         loss *= mask.to(loss.dtype)
 
         if self.classes is not None:
             loss = loss[self.classes]
 
-        return self.aggregate_loss(loss)
+        if self.reduction == MEAN_REDUCTION:
+            loss = torch.mean(loss)
+        elif self.reduction == SUM_REDUCTION:
+            loss = torch.sum(loss)
+        elif self.reduction == NONE_REDUCTION:
+            loss = loss.view(bs, num_classes, height, width)
 
-    def aggregate_loss(self, loss):
-        return loss.mean()
-
-    def compute_score(
-        self, output, target, smooth=0.0, eps=1e-7, dims=None
-    ) -> torch.Tensor:
-        return soft_dice_score(output, target, smooth, eps, dims)
+        return loss

--- a/torchseg/losses/reductions.py
+++ b/torchseg/losses/reductions.py
@@ -1,14 +1,3 @@
-
-#: NONE_REDUCTION mode: the output will be summed
-MEAN_REDUCTION: str = 'mean'
-
-#: SUM_REDUCTION mode: the output will be summed
-SUM_REDUCTION: str = 'sum'
-
-#: NONE_REDUCTION mode: no reduction will be applied
-NONE_REDUCTION: str = 'none'
-
-
 class LossReduction:
     """
     Class to represent different modes of reduction.

--- a/torchseg/losses/reductions.py
+++ b/torchseg/losses/reductions.py
@@ -1,0 +1,29 @@
+
+#: NONE_REDUCTION mode: the output will be summed
+MEAN_REDUCTION: str = 'mean'
+
+#: SUM_REDUCTION mode: the output will be summed
+SUM_REDUCTION: str = 'sum'
+
+#: NONE_REDUCTION mode: no reduction will be applied
+NONE_REDUCTION: str = 'none'
+
+
+class LossReduction:
+    """
+    Class to represent different modes of reduction.
+    - MEAN: the sum of the output will be divided by the number of elements in the output;
+    - SUM: the output will be summed;
+    - NONE: no reduction will be applied
+    """
+
+    MEAN = "mean"
+    SUM = "sum"
+    NONE = "none"
+
+    @staticmethod
+    def available_reductions():
+        return [LossReduction.MEAN, LossReduction.SUM, LossReduction.NONE]
+
+
+


### PR DESCRIPTION
Overhaul of torchseg.losses, starting from DiceLoss.

General changes applied to DiceLoss (to be applied later to all other losses):

- switched from `assert` to `warnings` and `raise`;
- eliminated the need of specifying `binary`, `multiclass` and `multilabels` modes when instantiating a loss function, by changing masks shape: now the shape must be [B, C, H, W] for multiclass and multilabels cases, [B, 1, H, W] for binary case. [B, 1, H, W] can be accepted also for multiclass case as long as `mask_to_one_hot = True`;
- introduction of proper reduction techniques (`MEAN`, `SUM`, `NONE`) and definition of a `LossReduction` class to easily save the techniques;

Specific changes applied to DiceLoss:

- added the argument `power` to be applied to the denominator of the DiceCoefficient (still need to add this to the documentation of the class)